### PR TITLE
float cmp with abs eps by default

### DIFF
--- a/float.go
+++ b/float.go
@@ -11,6 +11,7 @@ const (
 	minNormal64 = 0x1p-1022
 )
 
+// https://floating-point-gui.de/errors/comparison/
 func nearlyEqual(a, b, eps, minNormal, maxFloat float64) bool {
 	absA := math.Abs(float64(a))
 	absB := math.Abs(float64(b))
@@ -28,8 +29,9 @@ func nearlyEqual(a, b, eps, minNormal, maxFloat float64) bool {
 	return diff/math.Min((absA+absB), maxFloat) < eps
 }
 
-// AssertEqualFloat32 checks that two float32 values are equal.
-func AssertEqualFloat32(t *testing.T, v1, v2 float32, eps float64, msg ...interface{}) {
+// AssertRelEqualFloat32 checks that two float32 values are equal with relative eps.
+// https://floating-point-gui.de/errors/comparison/
+func AssertRelEqualFloat32(t *testing.T, v1, v2 float32, eps float64, msg ...interface{}) {
 	t.Helper()
 
 	if !nearlyEqual(float64(v1), float64(v2), eps, float64(minNormal32), float64(math.MaxFloat32)) {
@@ -37,8 +39,9 @@ func AssertEqualFloat32(t *testing.T, v1, v2 float32, eps float64, msg ...interf
 	}
 }
 
-// AssertEqualFloat64 checks that two float64 values are equal.
-func AssertEqualFloat64(t *testing.T, v1, v2 float64, eps float64, msg ...interface{}) {
+// AssertRelEqualFloat64 checks that two float64 values are equal with relative eps.
+// https://floating-point-gui.de/errors/comparison/
+func AssertRelEqualFloat64(t *testing.T, v1, v2 float64, eps float64, msg ...interface{}) {
 	t.Helper()
 
 	if !nearlyEqual(v1, v2, eps, minNormal64, math.MaxFloat64) {
@@ -46,8 +49,9 @@ func AssertEqualFloat64(t *testing.T, v1, v2 float64, eps float64, msg ...interf
 	}
 }
 
-// AssertNotEqualFloat32 checks that two float32 values are not equal.
-func AssertNotEqualFloat32(t *testing.T, v1, v2 float32, eps float64, msg ...interface{}) {
+// AssertRelNotEqualFloat32 checks that two float32 values are not equal with relative eps.
+// https://floating-point-gui.de/errors/comparison/
+func AssertRelNotEqualFloat32(t *testing.T, v1, v2 float32, eps float64, msg ...interface{}) {
 	t.Helper()
 
 	if nearlyEqual(float64(v1), float64(v2), eps, float64(minNormal32), float64(math.MaxFloat32)) {
@@ -55,11 +59,48 @@ func AssertNotEqualFloat32(t *testing.T, v1, v2 float32, eps float64, msg ...int
 	}
 }
 
-// AssertNotEqualFloat64 checks that two float64 values are not equal.
-func AssertNotEqualFloat64(t *testing.T, v1, v2 float64, eps float64, msg ...interface{}) {
+// AssertRelNotEqualFloat64 checks that two float64 values are not equal.
+// https://floating-point-gui.de/errors/comparison/
+func AssertRelNotEqualFloat64(t *testing.T, v1, v2 float64, eps float64, msg ...interface{}) {
 	t.Helper()
 
 	if nearlyEqual(v1, v2, eps, minNormal64, math.MaxFloat64) {
+		t.Fatal(v1, "!=", v2, msg)
+	}
+}
+
+// AssertEqualFloat32 checks that two float32 values are equal with absolute eps.
+func AssertEqualFloat32(t *testing.T, v1, v2 float32, eps float64, msg ...interface{}) {
+	t.Helper()
+
+	if math.Abs(float64(v1)-float64(v2)) > eps {
+		t.Fatal(v1, "!=", v2, msg)
+	}
+}
+
+// AssertEqualFloat64 checks that two float64 values are equal with absolute eps.
+func AssertEqualFloat64(t *testing.T, v1, v2 float64, eps float64, msg ...interface{}) {
+	t.Helper()
+
+	if math.Abs(v1-v2) > eps {
+		t.Fatal(v1, "!=", v2, msg)
+	}
+}
+
+// AssertNotEqualFloat32 checks that two float32 values are not equal with absolute eps.
+func AssertNotEqualFloat32(t *testing.T, v1, v2 float32, eps float64, msg ...interface{}) {
+	t.Helper()
+
+	if math.Abs(float64(v1)-float64(v2)) <= eps {
+		t.Fatal(v1, "!=", v2, msg)
+	}
+}
+
+// AssertNotEqualFloat64 checks that two float64 values are not equal with absolute eps.
+func AssertNotEqualFloat64(t *testing.T, v1, v2 float64, eps float64, msg ...interface{}) {
+	t.Helper()
+
+	if math.Abs(v1-v2) <= eps {
 		t.Fatal(v1, "!=", v2, msg)
 	}
 }

--- a/float_test.go
+++ b/float_test.go
@@ -11,8 +11,8 @@ func TestAssertEqualFloat32(t *testing.T) {
 	AssertEqualFloat32(t, 1.12346, 1.12345, 0.0001)
 	AssertEqualFloat32(t, 0.000000001000001, 0.000000001000002, 0.00001)
 	AssertEqualFloat32(t, 0.000000001000002, 0.000000001000001, 0.00001)
-	AssertNotEqualFloat32(t, 0.000000000001001, 0.000000000001002, 0.00001)
-	AssertNotEqualFloat32(t, 0.000000000001002, 0.000000000001001, 0.00001)
+	AssertRelNotEqualFloat32(t, 0.000000000001001, 0.000000000001002, 0.00001)
+	AssertRelNotEqualFloat32(t, 0.000000000001002, 0.000000000001001, 0.00001)
 }
 
 func TestAssertEqualFloat64(t *testing.T) {
@@ -21,8 +21,8 @@ func TestAssertEqualFloat64(t *testing.T) {
 	AssertEqualFloat64(t, 1.12346, 1.12345, 0.0001)
 	AssertEqualFloat64(t, 0.0000000010000001, 0.0000000010000002, 0.0000001)
 	AssertEqualFloat64(t, 0.0000000010000002, 0.0000000010000001, 0.0000001)
-	AssertNotEqualFloat64(t, 0.000000000001001, 0.000000000001002, 0.0000001)
-	AssertNotEqualFloat64(t, 0.000000000001002, 0.000000000001001, 0.0000001)
+	AssertRelNotEqualFloat64(t, 0.000000000001001, 0.000000000001002, 0.0000001)
+	AssertRelNotEqualFloat64(t, 0.000000000001002, 0.000000000001001, 0.0000001)
 }
 
 func TestAssertZeroFloat32(t *testing.T) {
@@ -32,13 +32,13 @@ func TestAssertZeroFloat32(t *testing.T) {
 
 	AssertEqualFloat32(t, 0.0, 1e-40, 0.1)
 	AssertEqualFloat32(t, 1e-40, 0.0, 0.1)
-	AssertNotEqualFloat32(t, 0.0, 1e-40, 0.000001)
-	AssertNotEqualFloat32(t, 1e-40, 0.0, 0.000001)
+	AssertRelNotEqualFloat32(t, 0.0, 1e-40, 0.000001)
+	AssertRelNotEqualFloat32(t, 1e-40, 0.0, 0.000001)
 
 	AssertEqualFloat32(t, 0.0, -1e-40, 0.1)
 	AssertEqualFloat32(t, -1e-40, 0.0, 0.1)
-	AssertNotEqualFloat32(t, 0.0, -1e-40, 0.000001)
-	AssertNotEqualFloat32(t, -1e-40, 0.0, 0.000001)
+	AssertEqualFloat32(t, 0.0, -1e-40, 0.000001)
+	AssertEqualFloat32(t, -1e-40, 0.0, 0.000001)
 }
 
 func TestAssertZeroFloat64(t *testing.T) {
@@ -48,13 +48,13 @@ func TestAssertZeroFloat64(t *testing.T) {
 
 	AssertEqualFloat64(t, 0.0, 1e-309, 0.1)
 	AssertEqualFloat64(t, 1e-309, 0.0, 0.1)
-	AssertNotEqualFloat64(t, 0.0, 1e-309, 0.000001)
-	AssertNotEqualFloat64(t, 1e-309, 0.0, 0.000001)
+	AssertRelNotEqualFloat64(t, 0.0, 1e-309, 0.000001)
+	AssertRelNotEqualFloat64(t, 1e-309, 0.0, 0.000001)
 
 	AssertEqualFloat64(t, 0.0, -1e-309, 0.1)
 	AssertEqualFloat64(t, -1e-309, 0.0, 0.1)
-	AssertNotEqualFloat64(t, 0.0, -1e-309, 0.000001)
-	AssertNotEqualFloat64(t, -1e-309, 0.0, 0.000001)
+	AssertEqualFloat64(t, 0.0, -1e-309, 0.000001)
+	AssertEqualFloat64(t, -1e-309, 0.0, 0.000001)
 }
 
 func TestAssertNotEqualFloat32(t *testing.T) {


### PR DESCRIPTION

# Сравнение вещественных чисел в популярных библиотеках для тестирования

## 1. Google Test (C++)

- **Метод сравнения:**
  - Google Test использует **абсолютное сравнение** для проверки вещественных чисел через макросы `EXPECT_NEAR`, `EXPECT_FLOAT_EQ` и `EXPECT_DOUBLE_EQ`.
- **Детали реализации:**
  - `EXPECT_NEAR` принимает пользовательский параметр `epsilon` для абсолютной погрешности:
    ```cpp
    EXPECT_NEAR(a, b, epsilon);
    ```
    Проверяется условие:

    |a - b| <= epsilon

  - `EXPECT_FLOAT_EQ` и `EXPECT_DOUBLE_EQ` используют **разницу в ULP** (единицы младшего разряда):
    ```cpp
    EXPECT_FLOAT_EQ(a, b);
    EXPECT_DOUBLE_EQ(a, b);
    ```
  - Если числа равны или их представления отличаются не более чем на 4 ULP (по умолчанию), сравнение считается успешным.

## 2. Testify (Go)

- **Метод сравнения:**
  - Библиотека Testify (пакет `assert`) реализует **абсолютное сравнение** через функцию `InDelta`.
- **Пример использования:**
  ```go
  import "github.com/stretchr/testify/assert"

  func TestFloatComparison(t *testing.T) {
      a := 0.1 + 0.2
      b := 0.3
      assert.InDelta(t, a, b, 0.0001, "Numbers are not within delta")
  }
  ```
- **Детали реализации:**
  Проверяется условие:

  |a - b| <= delta

  Для массивов используется функция `assert.InDeltaSlice`.

## 3. Pytest (Python)

- **Метод сравнения:**
  - Pytest предоставляет метод `math.isclose` или `pytest.approx` для сравнения вещественных чисел.
- **Пример использования:**
  ```python
  from math import isclose

  def test_floats():
      a = 0.1 + 0.2
      b = 0.3
      assert isclose(a, b, rel_tol=1e-9, abs_tol=0.0)
  ```
- **Детали реализации:**
  `isclose` реализует гибридный подход:

  |a - b| <= max(rel_tol * max(|a|, |b|), abs_tol)

  - `rel_tol`: относительная погрешность.
  - `abs_tol`: абсолютная погрешность (по умолчанию 0).

## 4. JUnit (Java)

- **Метод сравнения:**
  - В JUnit для сравнения чисел с плавающей запятой используется абсолютное сравнение.
- **Пример использования:**
  ```java
  import static org.junit.jupiter.api.Assertions.assertEquals;

  @Test
  void testFloats() {
      double a = 0.1 + 0.2;
      double b = 0.3;
      double epsilon = 1e-9;
      assertEquals(a, b, epsilon);
  }
  ```
- **Детали реализации:**
  Проверяется условие:

  |a - b| <= epsilon

## 5. Mocha + Chai (JavaScript)

- **Метод сравнения:**
  - Chai (assertion library для Mocha) предоставляет метод `closeTo` для абсолютного сравнения.
- **Пример использования:**
  ```javascript
  const { expect } = require('chai');

  it('should compare floating point numbers', () => {
      const a = 0.1 + 0.2;
      const b = 0.3;
      expect(a).to.be.closeTo(b, 0.0001);
  });
  ```
- **Детали реализации:**
  Проверяется условие:

  |a - b| <= delta

## 6. Catch2 (C++)

- **Метод сравнения:**
  - Catch2 использует как абсолютное сравнение, так и относительное (через `Approx`).
- **Пример использования:**
  ```cpp
  #include <catch2/catch_test_macros.hpp>

  TEST_CASE("Floating point comparison") {
      double a = 0.1 + 0.2;
      double b = 0.3;
      REQUIRE(a == Approx(b).epsilon(0.01));
  }
  ```
- **Детали реализации:**
  Гибридный подход:

  |a - b| <= epsilon * max(|a|, |b|)

## 7. Unittest (Python)

- **Метод сравнения:**
  - В Python `unittest` используется метод `assertAlmostEqual`, который реализует абсолютное сравнение.
- **Пример использования:**
  ```python
  import unittest

  class TestFloats(unittest.TestCase):
      def test_floats(self):
          a = 0.1 + 0.2
          b = 0.3
          self.assertAlmostEqual(a, b, places=7)
  ```
- **Детали реализации:**
  Сравнение происходит до указанного количества знаков после запятой (`places`).

## Итог

- **Абсолютное сравнение**: Используется в Google Test, Testify, JUnit, Chai, Unittest.
- **Относительное сравнение**: Поддерживается в Catch2, Pytest (`math.isclose`).
- **Гибридный подход**: Используется в Pytest, Catch2.

**ПО УМОЛЧАНИЮ EPS ВЕЗДЕ СЧИТАЕТСЯ АБСОЛЮТНЫМ, ПОЭТОМУ ЗДЕСЬ СДЕЛАЛ ТАКЖЕ, ОСТАВИВ ВОЗМОЖНОСТЬ ДЕЛАТЬ ОТНОСИТЕЛЬНОЕ СРАВНЕНИЕ ЧЕРЕЗ AssertRel[Not]Equal[32/64]**